### PR TITLE
Crash Logger and Portable Instance

### DIFF
--- a/essentials.html
+++ b/essentials.html
@@ -241,15 +241,14 @@
 
             <!-- Crash Logger -->
             <p>
-                <a class="link" href="https://github.com/yvileapsis/yUI-NVSE/releases/latest" target="_blank">
+                <a class="link" href="https://www.nexusmods.com/newvegas/mods/82540" target="_blank">
                     <h2 id="cobb">Crash Logger</h2>
                 </a>
             </p>
             <h2 class="install">Installation instructions:</h2>
-            <ol>
-                <li>Download the <strong>CrashLogger.zip</strong> from GitHub.</li>
-                <li>Install the mod manually with Mod Organizer.</li>
-            </ol>
+            <ul>
+                <li><b>Main Files - Crash Logger</b></li>
+            </ul>
             A DLL that logs raw crash data.
 
             <!-- NVTF -->

--- a/ttw.html
+++ b/ttw.html
@@ -181,7 +181,7 @@
                 <ul>
                     <li>If you do not see anything, you did not install TTW to the correct folder. Find out where the files were installed to and move them to
                         <br>
-                        <code>C:\Modding\MO2\mods\Tale of Two Wastelands</code>
+                        <code>C:\The Best of Times\mods\Tale of Two Wastelands</code>
                     </li>
                 </ul>
                 <li>Click the checkbox next to it in the left pane and the right pane should fill with plugins.</li>

--- a/ttw.html
+++ b/ttw.html
@@ -179,9 +179,12 @@
                 <li>Launch Mod Organizer 2, or if you kept it open, click the <img src="./img/mo2 refresh.webp" alt="MO2 refresh"> button at the top to refresh the left pane.</li>
                 <li>If you installed TTW correctly with the correct filepaths, you should see the <strong>Tale of Two Wastelands</strong> mod in the left pane of MO2.</li>
                 <ul>
-                    <li>If you do not see anything, you did not install TTW to the correct folder. Find out where the files were installed to and move them to
+                    <li>If you do not see anything, you did not install TTW to the correct folder.
+                        Find out where the files were installed to and move them to the <strong title="In MO2, select the folder button at the top and select Open Mods folder">mods folder</strong>.
                         <br>
-                        <code>C:\The Best of Times\mods\Tale of Two Wastelands</code>
+                        The path should look like this:
+                        <br>
+                        <code><strong title="Folder that contains ModOrganizer.exe">YOUR MOD ORGANIZER FOLDER</strong>\mods\Tale of Two Wastelands</code>
                     </li>
                 </ul>
                 <li>Click the checkbox next to it in the left pane and the right pane should fill with plugins.</li>

--- a/ttw.html
+++ b/ttw.html
@@ -181,7 +181,7 @@
                 <ul>
                     <li>If you do not see anything, you did not install TTW to the correct folder. Find out where the files were installed to and move them to
                         <br>
-                        <code>C:\Users\<strong>YOUR USERNAME</strong>\AppData\Local\ModOrganizer\TTW\mods\Tale of Two Wastelands</code>
+                        <code>Modding\MO2\mods\Tale of Two Wastelands</code>
                     </li>
                 </ul>
                 <li>Click the checkbox next to it in the left pane and the right pane should fill with plugins.</li>

--- a/ttw.html
+++ b/ttw.html
@@ -181,7 +181,7 @@
                 <ul>
                     <li>If you do not see anything, you did not install TTW to the correct folder. Find out where the files were installed to and move them to
                         <br>
-                        <code>Modding\MO2\mods\Tale of Two Wastelands</code>
+                        <code>C:\Modding\MO2\mods\Tale of Two Wastelands</code>
                     </li>
                 </ul>
                 <li>Click the checkbox next to it in the left pane and the right pane should fill with plugins.</li>


### PR DESCRIPTION
-Swaps the Github crash logger link with Nexus link
-Changes one of the global MO2 links to a portable location