### PR TITLE
Update instance creation step to use full name

### DIFF
--- a/mo2.html
+++ b/mo2.html
@@ -269,7 +269,7 @@
                             <img class="content-img" src="./img/MO2/Instance.webp" alt="Select Portable Instance option">
                             <div class="resize-overlay expand"></div>
                         </div>
-                        <li>Select <strong>TTW</strong> and click <b>Next</b>.</li>
+                        <li>Select <strong>Tale of Two Wastelands</strong> and click <b>Next</b>.</li>
                         <li>Select the store where you bought the game, click <b>Next</b>.</li>
                         <li>When asked about profile settings, <strong>enable all options</strong> and click <b>Next</b>.</li>
                         <li>Keep the <strong>default location</strong> file path.</li>


### PR DESCRIPTION
The name displayed during instance creation is now `Tale of Two Wastelands` so this is just an update for parity.