### PR TITLE
Update fo3.html with fps fix Nexus link

### DIFF
--- a/fo3.html
+++ b/fo3.html
@@ -361,11 +361,11 @@
 
                 <div class="card" id="HighFPSPhysicsFix" title="High FPS Physics Fix">
                     <p>
-                    <h3 class="link-download"><a href="https://github.com/c6-dev/fose-fps-fix/releases/download/1.1/HighFPSFix.zip" target="_blank">High FPS Physics Fix</a></h3>
+                    <h3 class="link-download"><a href="https://www.nexusmods.com/fallout3/mods/27036" target="_blank">High FPS Physics Fix</a></h3>
                     Fixes micro-stuttering, performance and allows playing at higher framerates (up to a safe maximum of ~120).
                     <h3 class="install">Installation instructions</h3>
                     <ul>
-                        <li>Download the mod, then install it manually by pressing the <img class="mo2-icon" src="./img/MO2/Install Archive.webp" alt="MO2 archive button"> button at the top of MO2 and selecting the file you just downloaded.</li>
+                        <li><b>Main Files</b> - High FPS Physics Fix</li>
                     </ul>
                     </p>
                 </div>


### PR DESCRIPTION
Replace installation instructions and download link for High FPS as it is now available on Nexus rather than c6-dev's own github.